### PR TITLE
WifiScanningService: Fix invalid offset error

### DIFF
--- a/service/java/com/android/server/wifi/WifiScanningServiceImpl.java
+++ b/service/java/com/android/server/wifi/WifiScanningServiceImpl.java
@@ -1008,7 +1008,7 @@ public class WifiScanningServiceImpl extends IWifiScanner.Stub {
             }
 
             int bestBucketIndex = -1;                                   // best by period
-            for (int i = 0; i < mTimeBuckets.length; i++) {
+            for (int i = 0; i < mTimeBuckets.length && i < mSettings.buckets.length; i++) {
                 TimeBucket bucket = mTimeBuckets[i];
                 if (bucket.periodMinInSecond * 1000 <= settings.periodInMs
                         && settings.periodInMs < bucket.periodMaxInSecond * 1000) {


### PR DESCRIPTION
The code currently assumes that mSettings.buckets is at least as
large as mTimeBuckets. The length of mSettings.buckets is determined
at runtime by querying the kernel via the WiFi HAL. In the event
that the query fails, the mSettings.buckets array will have a zero
size. The code will then try to access a nonexistent element in the
zero length array, leading to an array bounds error that brings down
the whole Android runtime.

This check protects against the crash that would occur when the
mSettings.buckets array is undersized.

Change-Id: Ic3fffd82c745922bd6378062ee188841880895a2
